### PR TITLE
Remove ENT_HTML5  PHP 5.4 constant usage which breaks PHP 5.3

### DIFF
--- a/lib/Bazaarvoice/bvseosdk.php
+++ b/lib/Bazaarvoice/bvseosdk.php
@@ -785,7 +785,7 @@ class Base {
       // contents.
       htmlspecialchars(
         $this->config['base_url'] . $page_url_query_prefix,
-        ENT_QUOTES | ENT_HTML5,
+        ENT_QUOTES,
         $this->config['charset'],
         // Don't double-encode.
         false

--- a/lib/Bazaarvoice/bvseosdk.php
+++ b/lib/Bazaarvoice/bvseosdk.php
@@ -779,16 +779,23 @@ class Base {
       }
     }
 
+    // ENT_HTML5 is only defined in PHP 5.4 or higher
+    if (version_compare(phpversion(), '5.4.0', '>=')) {
+      $flags = ENT_QUOTES | ENT_HTML5;
+    } else {
+      $flags = ENT_QUOTES;
+    }
+
     $content = mb_ereg_replace(
       '{INSERT_PAGE_URI}',
       // Make sure someone doesn't sneak in "><script>...<script> in the URL
       // contents.
       htmlspecialchars(
-        $this->config['base_url'] . $page_url_query_prefix,
-        ENT_QUOTES,
-        $this->config['charset'],
-        // Don't double-encode.
-        false
+          $this->config['base_url'] . $page_url_query_prefix,
+          $flags,
+          $this->config['charset'],
+          // Don't double-encode.
+          false
       ),
       $content
     );


### PR DESCRIPTION
ENT_HTML5 is a constant which is declared in PHP 5.4 onwards.

Then change in question will revert the quote encoding to use HTML401 style _&#39;_ instead of HTML5 _&apos;_ which I don't believe will have any impact of the validity of the data encoded